### PR TITLE
Update to Ansible 2.4

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+host_preparation_change_to_ubuntu_official_repository: false
+host_preparation_install_latest_kernel: false
+
 host_preparation_role_name: host_preparation
 
 #host_preparation_apt_cacher_ng: apt-cacher-ng.example.com

--- a/tasks/kernel.yml
+++ b/tasks/kernel.yml
@@ -7,6 +7,7 @@
        state: latest
     with_items:
       - linux-generic-lts-xenial
+    when: host_preparation_install_latest_kernel
 
   - name: Check if a reboot is required
     stat:
@@ -14,7 +15,7 @@
       get_md5: no
     register: file_reboot_required
 
-  - include: reboot.yml
+  - include_tasks: reboot.yml
     when: |
       file_reboot_required is defined and
       file_reboot_required.stat.exists == true
@@ -32,7 +33,7 @@
       get_md5: no
     register: file_reboot_required
 
-  - include: reboot.yml
+  - include_tasks: reboot.yml
     when: |
       file_reboot_required is defined and
       file_reboot_required.stat.exists == true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- include: apt_cacher_ng.yml
-- include: packages.yml
-- include: hostname.yml
-- include: kernel.yml
-- include: tuning.yml
-- include: reboot.yml
-- include: sshd.yml
-- include: user.yml
+- include_tasks: apt_cacher_ng.yml
+- include_tasks: packages.yml
+- include_tasks: hostname.yml
+- include_tasks: kernel.yml
+- include_tasks: tuning.yml
+- include_tasks: reboot.yml
+- include_tasks: sshd.yml
+- include_tasks: user.yml

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -5,6 +5,7 @@
       dest: /etc/apt/sources.list
       regexp: 'http://(.*).archive\.ubuntu\.com/ubuntu/'
       replace: 'http://archive.ubuntu.com/ubuntu/'
+    when: host_preparation_change_to_ubuntu_official_repository
 
   - name: Update packages to the latest version
     apt:

--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -14,7 +14,7 @@
     become: false
     wait_for:
       host: "{{ ansible_host }}"
-      port: "{{ ansible_port }}"
+      port: "{{ ansible_port | default(22) }}"
       state: stopped
     delegate_to: 127.0.0.1
     when: |
@@ -26,7 +26,7 @@
     become: false
     wait_for:
       host: "{{ ansible_host }}"
-      port: "{{ ansible_port }}"
+      port: "{{ ansible_port | default(22) }}"
       timeout: "{{ host_preparation_reboot_timeout }}"
       state: started
       search_regex: OpenSSH


### PR DESCRIPTION
- Add default ssh port when rebooted and try to reconnect
- Add some more variables for more control
- Change from include to include_tasks for Ansible 2.4