### PR TITLE
fix: match handler name

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,12 +1,12 @@
 ---
-- name: Restart sshd service (Debian/Ubuntu)
+- name: Restart sshd service
   service:
     name: ssh
     state: restarted
   when: ansible_os_family == 'Debian'
   notify: Change Ansible ssh port
 
-- name: Restart sshd service (CentOS/RHEL)
+- name: Restart sshd service
   service:
     name: sshd
     state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - setup:
+  - tags: always
 - import_tasks: apt_cacher_ng.yml
   when: ansible_os_family == 'Debian'
 - import_tasks: packages.yml
@@ -8,6 +9,6 @@
 - import_tasks: kernel.yml
 - import_tasks: tuning.yml
 - import_tasks: reboot.yml
-  when: host_preparation_need_reboot 
+  when: host_preparation_need_reboot
 - import_tasks: sshd.yml
 - import_tasks: user.yml


### PR DESCRIPTION
* Add `tags: always` because the playbook will be failed when run with the `-t host-preparation-configure-sshd` tag option.
* Change handler name to match with notify name in the sshd task.